### PR TITLE
Add Page Block translation extension

### DIFF
--- a/blocks_i18n/.gitignore
+++ b/blocks_i18n/.gitignore
@@ -1,0 +1,3 @@
+/coverage
+/spec/dummy
+/pkg

--- a/blocks_i18n/README.md
+++ b/blocks_i18n/README.md
@@ -1,0 +1,23 @@
+# Spree Blocks I18n
+
+This extension adds multi-language support for Page Builder blocks by leveraging
+Mobility's ActionText backend.
+
+## Installation
+
+Add the gem to your Spree application's `Gemfile`:
+
+```ruby
+gem 'spree_blocks_i18n', path: '../blocks_i18n'
+```
+
+Run the installer:
+
+```bash
+bin/rails spree_blocks_i18n:install
+```
+
+## Features
+
+* Translatable rich text for `Spree::PageBlock`
+* Translation form for Page Blocks in the admin panel

--- a/blocks_i18n/Rakefile
+++ b/blocks_i18n/Rakefile
@@ -1,0 +1,12 @@
+require 'rake'
+require 'spree/testing_support/common_rake'
+
+RSpec::Core::RakeTask.new
+
+task default: :spec
+
+desc 'Generates a dummy app for testing'
+task :test_app do
+  ENV['LIB_NAME'] = 'spree/blocks_i18n'
+  Rake::Task['common:test_app'].invoke
+end

--- a/blocks_i18n/app/overrides/add_translations_button_to_page_blocks.rb
+++ b/blocks_i18n/app/overrides/add_translations_button_to_page_blocks.rb
@@ -1,0 +1,6 @@
+Deface::Override.new(
+  virtual_path: 'spree/admin/page_blocks/edit',
+  name: 'add_translations_button_to_page_blocks',
+  insert_after: "h6.sidebar-header",
+  text: "<%= link_to_edit_translations(@page_block, classes: 'btn btn-light mb-3') %>"
+)

--- a/blocks_i18n/app/views/spree/admin/translations/edit.html.erb
+++ b/blocks_i18n/app/views/spree/admin/translations/edit.html.erb
@@ -1,0 +1,49 @@
+<% content_for :page_title do %>
+  <%= page_header_back_button @back_path %>
+  <span class="mr-3"><%= Spree.t(:translations_for, resource_name: @resource_name) %></span>
+<% end %>
+<% if @locales.any?%>
+  <% if @locales.many? %>
+    <%= form_with url: spree.edit_admin_translation_path(@resource, resource_type: @resource.class.to_s), class: "w-100 d-flex justify-content-end", data: { controller: 'auto-submit', turbo_frame: 'translations_table'}, method: :get do |f| %>
+      <div class="form-inline gap-2">
+        <%= f.label :translation_locale, Spree.t(:language) %>
+        <%= f.select :translation_locale, options_for_select(@locales.map { |locale| [Spree.t('i18n.this_file_language', locale: locale), locale] }, @selected_translation_locale), {}, { class: 'custom-select', data: { action: 'change->auto-submit#submit' } } %>
+      </div>
+    <% end %>
+  <% end %>
+  <%= form_with url: spree.admin_translation_path(@resource, resource_type: @resource.class.to_s), method: :put, class: 'form-horizontal' do |f| %>
+    <%= turbo_frame_tag :translations_table, class: "table-responsive border rounded bg-white my-3", refresh: "morph" do %>
+      <%= hidden_field_tag :translation_locale, @selected_translation_locale %>
+      <table class="table">
+        <thead>
+          <tr>
+            <th scope="col" class="text-center"><%= Spree.t(:field) %></th>
+            <th scope="col" class="text-center" style="width: 40%;"><%= Spree.t('i18n.this_file_language', locale: :en) %> (<%= Spree.t(:default) %>)</th>
+            <th scope="col" class="text-center"><%= Spree.t('i18n.this_file_language', locale: @selected_translation_locale) %></th>
+          </tr>
+        </thead>
+        <tbody>
+          <% options = { resource: @resource, selected_translation_locale: @selected_translation_locale } %>
+          <% case @resource %>
+          <% when Spree::Product %>
+            <%= render 'spree/admin/translations/products/form', options %>
+          <% when Spree::Taxon %>
+            <%= render 'spree/admin/translations/taxons/form', options %>
+          <% when Spree::Taxonomy %>
+            <%= render 'spree/admin/translations/taxonomies/form', options %>
+          <% when Spree::Store %>
+            <%= render 'spree/admin/translations/stores/form', options %>
+          <% when Spree::PageBlock %>
+            <%= render 'spree/admin/translations/page_blocks/form', options %>
+          <% end %>
+        </tbody>
+      </table>
+    <% end %>
+    <div class="form-actions">
+      <%= turbo_save_button_tag Spree.t('actions.update') %>
+      <%= link_to Spree.t('actions.cancel'), @back_path, class: 'btn btn-light ml-auto' %>
+    </div>
+  <% end %>
+<% else %>
+  <%= render partial: 'spree/admin/translations/translations_unavailable' %>
+<% end %>

--- a/blocks_i18n/app/views/spree/admin/translations/page_blocks/_form.html.erb
+++ b/blocks_i18n/app/views/spree/admin/translations/page_blocks/_form.html.erb
@@ -1,0 +1,15 @@
+<% resource.class.translatable_fields.each do |field| %>
+  <tr>
+    <td class="text-left">
+      <%= Spree.t(field) %>
+    </td>
+    <% [@default_locale, selected_translation_locale].each do |translation_locale| %>
+      <% readonly = translation_locale == @default_locale %>
+      <td <% if readonly %>style="width: 40%;"<% else %>style="width: 60%;"<% end %>>
+        <div class="trix-container mb-0">
+          <%= rich_text_area_tag "translation[#{field}][#{translation_locale}]", resource.get_field_with_locale(translation_locale, field), { contenteditable: !readonly } %>
+        </div>
+      </td>
+    <% end %>
+  </tr>
+<% end %>

--- a/blocks_i18n/db/migrate/20240101000000_add_locale_to_action_text.rb
+++ b/blocks_i18n/db/migrate/20240101000000_add_locale_to_action_text.rb
@@ -1,0 +1,17 @@
+class AddLocaleToActionText < ActiveRecord::Migration[6.1]
+  def change
+    if table_exists?(:action_text_rich_texts) && !column_exists?(:action_text_rich_texts, :locale)
+      add_column :action_text_rich_texts, :locale, :string, null: false
+
+      remove_index :action_text_rich_texts,
+                   column: %i[record_type record_id name],
+                   name: :index_action_text_rich_texts_uniqueness,
+                   unique: true
+
+      add_index :action_text_rich_texts,
+                %i[record_type record_id name locale],
+                name: :index_action_text_rich_texts_uniqueness,
+                unique: true
+    end
+  end
+end

--- a/blocks_i18n/lib/generators/spree/blocks_i18n/install/install_generator.rb
+++ b/blocks_i18n/lib/generators/spree/blocks_i18n/install/install_generator.rb
@@ -1,0 +1,20 @@
+module SpreeBlocksI18n
+  module Generators
+    class InstallGenerator < Rails::Generators::Base
+      class_option :migrate, type: :boolean, default: true
+
+      def add_migrations
+        run 'bundle exec rake railties:install:migrations FROM=blocks_i18n'
+      end
+
+      def run_migrations
+        run_migrations = options[:migrate] || ['', 'y', 'Y'].include?(ask('Would you like to run the migrations now? [Y/n]'))
+        if run_migrations
+          run 'bin/rails db:migrate'
+        else
+          puts 'Skipping rails db:migrate, don\'t forget to run it!'
+        end
+      end
+    end
+  end
+end

--- a/blocks_i18n/lib/spree/blocks_i18n/page_block_decorator.rb
+++ b/blocks_i18n/lib/spree/blocks_i18n/page_block_decorator.rb
@@ -1,0 +1,14 @@
+module SpreeBlocksI18n
+  module PageBlockDecorator
+    extend ActiveSupport::Concern
+
+    included do
+      include Spree::TranslatableResource
+
+      TRANSLATABLE_FIELDS = %i[text].freeze
+      translates(*TRANSLATABLE_FIELDS, backend: :action_text)
+    end
+  end
+end
+
+Spree::PageBlock.prepend SpreeBlocksI18n::PageBlockDecorator

--- a/blocks_i18n/lib/spree/blocks_i18n/translations_controller_decorator.rb
+++ b/blocks_i18n/lib/spree/blocks_i18n/translations_controller_decorator.rb
@@ -1,0 +1,14 @@
+module SpreeBlocksI18n
+  module TranslationsControllerDecorator
+    def load_data
+      super
+      case @resource
+      when Spree::PageBlock
+        @resource_name = @resource.display_name
+        @back_path = spree.edit_admin_theme_path(@resource.section.theme, page_id: @resource.section.page_id)
+      end
+    end
+  end
+end
+
+Spree::Admin::TranslationsController.prepend SpreeBlocksI18n::TranslationsControllerDecorator

--- a/blocks_i18n/lib/spree_blocks_i18n.rb
+++ b/blocks_i18n/lib/spree_blocks_i18n.rb
@@ -1,0 +1,16 @@
+require 'spree/core'
+require 'spree/admin'
+require 'deface'
+require 'spree_blocks_i18n/version'
+
+module SpreeBlocksI18n
+  class Engine < Rails::Engine
+    engine_name 'spree_blocks_i18n'
+
+    initializer 'spree.blocks_i18n.register_translatable_resources', after: 'spree.register.translatable_resources' do
+      Rails.application.config.spree.translatable_resources << Spree::PageBlock unless Rails.application.config.spree.translatable_resources.include?(Spree::PageBlock)
+    end
+  end
+end
+
+require 'spree/blocks_i18n/page_block_decorator'

--- a/blocks_i18n/lib/spree_blocks_i18n/version.rb
+++ b/blocks_i18n/lib/spree_blocks_i18n/version.rb
@@ -1,0 +1,3 @@
+module SpreeBlocksI18n
+  VERSION = '0.0.1'
+end

--- a/blocks_i18n/spree_blocks_i18n.gemspec
+++ b/blocks_i18n/spree_blocks_i18n.gemspec
@@ -1,0 +1,21 @@
+# encoding: UTF-8
+require_relative '../core/lib/spree/core/version.rb'
+
+Gem::Specification.new do |s|
+  s.platform    = Gem::Platform::RUBY
+  s.name        = 'spree_blocks_i18n'
+  s.version     = Spree.version
+  s.authors     = ['Example Author']
+  s.email       = 'dev@example.com'
+  s.summary     = 'Adds translations for Spree Page Builder blocks'
+  s.description = 'Extension providing multi-language content for storefront page blocks.'
+  s.homepage    = 'https://example.com'
+  s.license     = 'AGPL-3.0-or-later'
+
+  s.files        = Dir['{app,lib}/**/*', 'LICENSE', 'README.md']
+  s.require_path = 'lib'
+
+  s.add_dependency 'spree_core', ">= #{s.version}"
+  s.add_dependency 'spree_admin', ">= #{s.version}"
+  s.add_dependency 'deface'
+end


### PR DESCRIPTION
## Summary
- add `spree_blocks_i18n` extension
- implement translated rich text for `Spree::PageBlock`
- expose translation editing path for page blocks
- add generator and migration

## Testing
- `bundle exec rake test:units` *(fails: rbenv version not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68438995de54832286a043c6d233bd43